### PR TITLE
Revert mypy to 1.4.1 in pre-commit

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       language_version: python3
       args: [--line-length={{ cookiecutter.max_line_length }}]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.0
+    rev: v1.4.1
     hooks:
     - id: mypy
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
1.5.0 isn't available yet in pre-commit so reverting for now.