### PR TITLE
Remove rust toolchain action

### DIFF
--- a/{{cookiecutter.project_slug}}/actions/testing_all_os.yml
+++ b/{{cookiecutter.project_slug}}/actions/testing_all_os.yml
@@ -15,12 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo clippy
@@ -33,12 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo fmt

--- a/{{cookiecutter.project_slug}}/actions/testing_linux_only.yml
+++ b/{{cookiecutter.project_slug}}/actions/testing_linux_only.yml
@@ -15,12 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo clippy
@@ -33,12 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2.6.0
     - name: Run cargo fmt


### PR DESCRIPTION
The Rust toolchain action is no longer supported and throwing warnings so removing and installing rust without the action.